### PR TITLE
Bug line 103 in generateAggregateData.py

### DIFF
--- a/Ch02/generateAggregateData.py
+++ b/Ch02/generateAggregateData.py
@@ -100,7 +100,7 @@ for idx in range(yearJoined.shape[0]):
     join_date = min(join_date, pd.Timestamp('2018-06-01'))
     
     ## user should not receive emails or make donations before joining
-    user_rng = rng[rng > join_date]    
+    user_rng = rng[rng.start_time > join_date]    
     
     if len(user_rng) < 1:
         continue


### PR DESCRIPTION
Fixing comparison between Timestamp and PeriodIndex intances adding `start_time` attribute to `rng`.